### PR TITLE
Sanitize ingredient-phrase pollution from recipe tags

### DIFF
--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -1,56 +1,25 @@
-# Assumptions — Fix Dietary Filter Veto
+# Assumptions — Clean Recipe Tags
 
 Living doc. Planning-phase assumptions start here; append as implementation sub-agents surface more.
 
 ## Planning-phase
 
-1. The `>=3` fallback at `MealPlanAction.ts:155` was an early defensive guard
-   against an empty meal plan, not an intentional product decision to relax
-   dietary constraints. Removing it is the correct fix.
-2. Dietary tags are **mandatory** when set (the `DietaryInvariant.ts` test
-   asserts this). They are not soft preferences.
-3. The recipe corpus contains enough vegan/gluten-free/dairy-free/nut-free
-   tagged recipes for personas to plan a full week. If not, the right fix is
-   to expand the corpus, not to silently serve non-compliant recipes.
-4. Tag normalization in `src/mappers/recipeMappers.ts:102–116` is sufficient
-   — kebab-case lowercase tags reach the filter intact. No new normalization
-   is required.
-5. Allergies and restrictions (`DietaryPreferences.allergies`,
-   `DietaryPreferences.restrictions`) are out of scope for this fix; the
-   simulation violations are all about the boolean flags
-   (`vegan`/`vegetarian`/`glutenFree`/`dairyFree`/`nutFree`/`lowCarb`).
-6. The ranker (`rankRecipes`) does not need dietary awareness: filtering
-   upstream gives it a clean compliant pool, so adding dietary features to
-   the score would be redundant.
-7. Centralizing `DIETARY_TAG_MAP` into a shared utility will not break the
-   simulation invariant validator as long as its `label` field is preserved.
+1. **`allrecipes_firestore.json` is the canonical corpus dump.** Tasty data is structured at scrape time and less polluted; this PR does not retroactively backfill Tasty recipes, only guards them at write time.
+2. **Heuristic filtering is preferable to strict allowlisting.** A strict allowlist would drop legitimate but uncatalogued tags. Heuristics + an ingredient-noun denylist + a positive-signal category vocabulary preserves unknowns while killing obvious pollution.
+3. **Tag schema stays flat (`string[]`).** Splitting into structured categories (`{ cuisine, mealType, dietary }`) is out of scope; would touch every reader and is a separate refactor.
+4. **The simulation harness (`KitchenSinkNew/simulation`) is the integration validator.** Loads the corpus, exercises every tag-based filter. Post-fix invariants and signal distributions are the success metric.
+5. **Tag normalization (lowercase + trim + dedupe) folds into `cleanTags`.** The existing `normalizeTags` in `dietaryFilter.ts` is replaced by a shared sanitizer, eliminating drift between dietary filtering and other tag consumers.
+6. **Cleaned JSON ships separately from the in-place file.** Script writes `allrecipes_firestore.cleaned.json` rather than mutating the original — preserves a re-runnable source of truth and lets reviewers diff the result.
+7. **Dry-run by default for Firestore writes.** The cleanup script does not touch Firestore unless `--apply-firestore` is passed, mirroring the safety pattern of one-time data migrations.
 
 ## Implementation-phase
 
-8. Production scope **expanded** during implementation. The user confirmed the
-   production app shares this bug. Two additional sites needed migration:
-   - `src/utils/mealPlanSelector.ts` — `meetsAllDietaryRequirements()` and
-     three more in-file tag-check sites (`calculateDietaryScore` and
-     `essentialDietaryFilter`) hardcoded only 4 of the 6 dietary flags
-     (missing `nutFree` and `lowCarb`). All migrated to `passesDietaryFilter`.
-   - `src/services/recommendationMealPlanService.ts` — added a defensive
-     post-fetch dietary filter so the ranker only sees compliant candidates,
-     mirroring the simulation fix.
-9. The shared module's hyphenated-only tag matching (e.g. `'gluten-free'`
-   only, not `'gluten free'`) is acceptable because `recipeMappers.ts:102–116`
-   normalizes spaced/underscored variants to hyphenated at ingest time.
-   The previous `DietaryInvariant` accepted both forms — this was defensive
-   redundancy that is no longer needed.
-10. Promoting the production `essentialDietaryFilter` from a 2-flag gate
-    (vegan/vegetarian only) to a 6-flag gate is a deliberate behavior change.
-    The original code's "ethical-only" carve-out is the precise pattern that
-    let `nutFree` violations through. This is the fix.
-11. Q2 (ranker dietary bonus as soft signal) deferred. Once the filter runs
-    upstream of the ranker, every candidate is compliant — a soft "dietary
-    fit" feature would always be 1.0 and contribute nothing to ranking. The
-    bonus is only meaningful if the filter is soft, which it no longer is.
-    Logged in QUESTIONS.md as accepted-but-deferred.
-12. Tests live at `src/utils/__tests__/dietaryFilter.test.ts` per `jest.config.js`
-    `testMatch` pattern. Jest is configured (`ts-jest` preset) but the binary
-    is not installed locally; the suite was not run as part of this commit.
-    Tests will run in CI / `npm install`-fresh environments.
+8. **Rule 3 threshold is "4+ words drops" (`words.length > 3`).** This lets `'garlic shrimp american'` survive rule 3 so rule 6's allowlist override is what saves it, matching the spec's narrative.
+9. **Measurement-token matching uses plain substring `String.includes`.** Catches both single-word (`tablespoon` inside `tablespoons`) and multi-word (`lightly salted`, `room temperature`) tokens. Spec allowed either word-boundary or substring for single-word entries.
+10. **Ingredient nouns matched with `\b<noun>\b` regex word boundaries.** Prevents `'onion'` from misfiring inside `'onions'` etc. The corollary cases (`'onions for garnish'`, `'chopped onions'`) are dropped via rules 4 and 5 respectively.
+11. **JS↔TS interop chose option (a): `ts-node/register/transpile-only` in `firestore-uploader.js`.** `ts-node` is a confirmed devDependency in `KitchenSinkNew/package.json`. Keeps `tagSanitizer.ts` as a single source of truth (no JS port, no `dist/` build step).
+12. **Backfill script adds a `clean:tags` npm script.** Uses `tsx` (already in devDependencies) for execution: `tsx scripts/clean-corpus-tags.ts`.
+13. **Backfill script Firestore mode auto-detects emulator vs production.** `FIRESTORE_EMULATOR_HOST` env var → emulator (no creds); otherwise `admin.credential.applicationDefault()` (requires `GOOGLE_APPLICATION_CREDENTIALS`).
+14. **Backfill batches Firestore updates at 400/batch.** Firestore caps at 500; 100-write headroom.
+15. **Backfill uses `batch.update(ref, { tags })` — only the `tags` field is touched on production docs.** No risk of clobbering unrelated fields.
+16. **Importer applies the sanitizer via spread-copy:** `const cleaned = { ...recipe, tags: cleanTags(recipe.tags) }` then `batch.set(ref, cleaned)`. Single mutation point, doesn't refactor surrounding logic.

--- a/IMPLEMENTATION_SPEC.md
+++ b/IMPLEMENTATION_SPEC.md
@@ -1,113 +1,134 @@
-# Fix Dietary Filter Veto
+# Implementation Spec: Clean Recipe Tags
 
-## Problem
+## Problem Statement
 
-The simulation harness emits 658 invariant violations; **610 (93%)** match the pattern
-`Recipe "X" lacks required Y tag for Y preference`. The planner serves vegan-explorer
-non-vegan recipes (e.g. "Roasted Garlic Butter", "Dina's Hot and Spicy Tuna"),
-serves dairy-free-beginner dairy-laden recipes ("Broccoli Rice and Cheese"), and
-serves allergy-aware-japanese (gluten-free + nut-free required) recipes carrying
-neither tag.
+The recipe corpus stored at `KitchenSinkNew/allrecipes_firestore.json` (~19K recipes) and mirrored into Firestore has tag pollution: ingredient phrases scraped from Allrecipes leaked into the `tags: string[]` field alongside legitimate tags.
 
-## Root Cause
-
-`KitchenSinkNew/simulation/actions/MealPlanAction.ts:148–155`:
-
-```ts
-const filtered = scored.filter(s => passesDietaryFilter(s.recipe, dietary));
-const candidates = filtered.length >= 3 ? filtered : scored;
+Concrete example from the corpus — "Roasted Garlic Butter":
 ```
+['american', 'bulb garlic', 'dinner', 'lightly salted whipped butter',
+ 'olive oil to drizzle over garlic', 'vegetarian']
+```
+Three of those six entries are ingredient phrases, not tags.
 
-When fewer than 3 ranked recipes pass the dietary filter, the filter is **silently
-discarded** and the unfiltered ranked list is used. This is the dominant source
-of the 93% violation rate.
+This contaminates every tag-driven filter and ranker:
+- Dietary hard-veto (`src/utils/dietaryFilter.ts`, recently merged in `28d8b01`).
+- Seasonal tag prior (`src/ranking/seasonalSignal.ts`, open PR #12 `b62927f`).
+- Cuisine and meal-type lookups (`src/data/recipeDatabase.ts`).
+- Feature engineering (`src/ranking/featureEngineering.ts`).
 
-Two contributing structural problems:
+Cleaning the tag set is a prerequisite for any of these filters to behave correctly.
 
-1. **Filter runs after the ranker.** The ranker scores generic appeal (similarity,
-   pantry overlap, seasonality, etc.) with no dietary awareness, so non-compliant
-   recipes can dominate the top of the list, and the post-filter then discards
-   most of the candidate pool — triggering the fallback.
-2. **No hard veto.** Dietary preferences are treated as soft annotations rather
-   than mandatory constraints.
+## Goals
 
-The mapping logic itself (`DIETARY_TAG_MAP` in `MealPlanAction.ts:38–48` and the
-identical map in `simulation/invariants/DietaryInvariant.ts:22–36`) is correct.
-Tag normalization in `src/mappers/recipeMappers.ts:102–116` is correct
-(`"dairy free"` → `"dairy-free"`, lowercasing, etc.). The bug is purely the
-silent fallback plus pipeline ordering.
+1. **Backfill** — cleanse tags in the existing corpus (JSON file + Firestore `recipes` collection) so all consumers see a clean index immediately.
+2. **Guard** — apply the same cleansing at every write path so new scrapes cannot reintroduce pollution.
+3. **Reuse** — one sanitizer module, used by scrapers, the bulk importer, and the dietary normalizer (DRY).
+
+Out of scope: splitting tags into structured categories (`{ cuisine, mealType, dietary }`); inferring missing tags from name/ingredients; retroactively backfilling Tasty corpus (the Tasty pipeline produces tags via `generateRecipeTags()` from structured fields, not free-text scraping — addressed defensively by the shared guard but not retroactively).
 
 ## Approach
 
-1. **Filter before ranking.** Move the dietary filter upstream of `rankRecipes()`
-   in `MealPlanAction.ts`. The ranker only sees diet-compliant recipes; whatever
-   it ranks is safe to select.
-2. **Remove the fallback.** No silent relaxation. If the compliant pool is empty,
-   surface a clear error (let the simulation/app decide how to handle scarcity
-   rather than masking the constraint violation).
-3. **Promote the helpers.** Move `DIETARY_TAG_MAP` and `passesDietaryFilter` out
-   of the simulation action into a shared module so the production app and the
-   invariant validator can both consume them. Eliminates the duplicated map in
-   `DietaryInvariant.ts` (DRY).
-4. **Tests.** Unit tests covering: each preference key vetoes correctly, multi-
-   constraint personas (gluten-free + nut-free) require both tags, an empty
-   compliant pool does not silently degrade.
+**Two-pronged fix.** A shared sanitizer module is the single source of truth. A one-time backfill script rewrites the corpus. A handful of write-path call sites adopt the sanitizer. The dietary filter's existing `normalizeTags()` delegates to the sanitizer.
+
+### Detecting ingredient-phrase pollution
+
+Hybrid: structural heuristics drop obvious ingredient phrases; everything else is preserved (we don't enforce a strict allowlist because that would drop legitimate but uncatalogued tags).
+
+A tag is dropped if **any** of these is true:
+1. Contains a comma (`,`) — real tags do not have commas.
+2. Length exceeds 25 characters — real tags are short ("comfort food", "gluten-free", "low-carb").
+3. Has 4 or more whitespace-separated words.
+4. Contains a preposition phrase: ` to `, ` for `, ` with `, ` of `, ` over `, ` from `, ` in ` (post-trim, lowercased, padded with spaces).
+5. Contains a measurement / preparation token: `teaspoon`, `tablespoon`, `tbsp`, `tsp`, `cup`, `ounce`, `oz`, `gram`, `lb`, `pound`, `drizzle`, `chopped`, `grated`, `sliced`, `diced`, `minced`, `peeled`, `melted`, `softened`, `whipped`, `room temperature`, `unsalted`, `lightly salted`.
+6. Contains an ingredient-root noun (`garlic`, `butter`, `oil`, `sugar`, `flour`, `egg`, `milk`, `salt`, `pepper`, `onion`, `tomato`, `cheese`, `chicken`, `beef`, `pork`, `fish`, `shrimp`, `bread`, `rice`, `pasta`) AND no token from `KNOWN_TAG_VOCABULARY` (the positive-signal allowlist below).
+
+Validated against the user's example:
+- `'american'` ✓ keep (rule 6 sees no ingredient noun).
+- `'bulb garlic'` ✗ drop (rule 6 — `garlic` is an ingredient noun, no allowlist token).
+- `'dinner'` ✓ keep.
+- `'lightly salted whipped butter'` ✗ drop (rule 5 — `lightly salted`, `whipped`).
+- `'olive oil to drizzle over garlic'` ✗ drop (rule 3 — 6 words; rule 4 — ` to `, ` over `; rule 5 — `drizzle`).
+- `'vegetarian'` ✓ keep.
+
+### Canonical vocabulary (`KNOWN_TAG_VOCABULARY`)
+
+Built from existing code references plus light corpus inspection:
+
+- **Dietary:** `vegan`, `vegetarian`, `gluten-free`, `dairy-free`, `nut-free`, `low-carb`, `keto`, `paleo`, `pescatarian`, `kosher`, `halal`.
+- **Meal type:** `breakfast`, `lunch`, `dinner`, `snacks`, `snack`, `dessert`, `appetizer`, `side dish`, `main course`, `brunch`.
+- **Cuisine:** `american`, `italian`, `mexican`, `asian`, `chinese`, `japanese`, `thai`, `indian`, `french`, `mediterranean`, `greek`, `middle eastern`, `southern`, `tex-mex`, `cajun`, `korean`, `vietnamese`, `spanish`, `german`, `british`.
+- **Cooking style/method:** `baked`, `grilled`, `fried`, `roasted`, `slow cooker`, `instant pot`, `air fryer`, `one pot`, `no cook`, `make ahead`.
+- **Dish character:** `comfort food`, `healthy`, `quick`, `easy`, `kid friendly`, `holiday`, `summer`, `winter`, `spring`, `fall`.
+
+The sanitizer does **not** require tags to match this vocab; it uses it only as a positive signal that overrides rule 6.
+
+### Algorithm (single function)
+
+```ts
+export function cleanTags(raw: readonly string[] | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const t of raw) {
+    const norm = t.trim().toLowerCase();
+    if (!norm || seen.has(norm)) continue;
+    if (isLikelyIngredientPhrase(norm)) continue;
+    seen.add(norm);
+    result.push(norm);
+  }
+  return result;
+}
+```
+
+Same function handles trim + lowercase + dedupe + filter, replacing `dietaryFilter.normalizeTags`.
+
+## Files to Create
+
+1. **`KitchenSinkNew/src/utils/tagSanitizer.ts`**
+   - Exports: `cleanTags`, `isLikelyIngredientPhrase`, `KNOWN_TAG_VOCABULARY`, `INGREDIENT_NOUN_DENYLIST`, `MEASUREMENT_TOKENS`.
+   - Single source of truth. No dependencies beyond stdlib strings.
+2. **`KitchenSinkNew/src/utils/__tests__/tagSanitizer.test.ts`**
+   - Given/When/Then style.
+   - Cases: the "Roasted Garlic Butter" example end-to-end; per-rule positive/negative; null/undefined input; case-insensitive dedupe; preserves order.
+3. **`KitchenSinkNew/scripts/clean-corpus-tags.ts`**
+   - Reads `KitchenSinkNew/allrecipes_firestore.json`, applies `cleanTags`, writes `KitchenSinkNew/allrecipes_firestore.cleaned.json`.
+   - Emits a report to stdout: total tags before/after, top 100 dropped tags by frequency, recipes whose tag count fell below 2 (for manual review).
+   - Has a `--apply-firestore` flag that batch-updates the Firestore `recipes` collection (uses existing Firestore admin pattern from `simulation/seed-data/import-recipes.ts`).
+   - Default is dry-run safe: only writes the `.cleaned.json` and the report; does not touch Firestore unless flagged.
 
 ## Files to Modify
 
-| File | Change |
-|------|--------|
-| `KitchenSinkNew/src/utils/dietaryFilter.ts` | **NEW**: export `DIETARY_TAG_MAP`, `passesDietaryFilter`, `filterByDiet`. Single source of truth. |
-| `KitchenSinkNew/simulation/actions/MealPlanAction.ts` | Filter recipes by diet **before** `rankRecipes()`. Remove `filtered.length >= 3 ? filtered : scored` fallback. Import from `dietaryFilter.ts`. |
-| `KitchenSinkNew/simulation/invariants/DietaryInvariant.ts` | Replace local `DIETARY_TAG_REQUIREMENTS` with import from `dietaryFilter.ts` (preserve `label` field if needed via small adapter). |
-| `KitchenSinkNew/src/utils/__tests__/dietaryFilter.test.ts` | **NEW**: unit tests for the helpers. |
+1. **`KitchenSinkNew/src/utils/dietaryFilter.ts`** (line 54)
+   - Replace inline `normalizeTags` with `import { cleanTags } from './tagSanitizer'`. Either rename `normalizeTags` to delegate, or remove it and update its 1-2 callers in this file. DRY win.
+2. **`KitchenSinkNew/scripts/tasty-scraper/firestore-uploader.js`** (around line 22)
+   - After `tags = generateRecipeTags(scrapedRecipe)`, run through `cleanTags`. JS file consumes TS via build output if needed; resolution flagged in `QUESTIONS.md`.
+3. **`KitchenSinkNew/simulation/seed-data/import-recipes.ts`** (lines 11–25)
+   - Defensively apply `cleanTags` per recipe during import. Belt-and-suspenders: even if the cleaned JSON is the input, this guarantees no polluted recipe ever lands in the simulation Firestore.
 
-## Files to Add
-
-- `KitchenSinkNew/src/utils/dietaryFilter.ts`
-- `KitchenSinkNew/src/utils/__tests__/dietaryFilter.test.ts`
+Note: after the backfill script runs and the `.cleaned.json` is the canonical corpus, the importer's defensive cleaning is a no-op for that source — but it remains correct insurance.
 
 ## Test Strategy
 
-### Unit (new)
-- `passesDietaryFilter` returns `false` when a required tag is absent.
-- Returns `true` when all required tags are present.
-- Multi-constraint user (gluten-free + nut-free) requires **both** tags.
-- Tag matching is case-insensitive and accepts both `"dairy-free"` and
-  `"dairy free"` shapes (mirrors existing `DIETARY_TAG_MAP`).
-- Allergies/restrictions arrays do not crash the filter when empty.
+- **Unit:** `tagSanitizer.test.ts` covers each rule and the canonical example.
+- **Regression:** add one fixture-based test in `dietaryFilter.test.ts` proving a polluted recipe still filters identically once tags are cleaned (i.e., dietary signal survives).
+- **End-to-end via simulation:** run the existing simulation harness (`KitchenSinkNew/simulation`) against the cleaned corpus. `DietaryInvariant` should remain at zero violations (post-`28d8b01`); seasonal signal distribution should sharpen. Report deltas in the PR body.
 
-### Integration / simulation
-- Re-run the simulation harness. The `Recipe X lacks required Y tag for Y
-  preference` violation count must drop to 0 for the personas listed in the
-  bug report (vegan-explorer, dairy-free-beginner, allergy-aware-japanese).
-- If the compliant pool is empty for a persona, the planner should surface a
-  diagnostic rather than emit silent violations.
-
-### No-mock policy
-Tests use real `UnifiedRecipe` and `DietaryPreferences` objects per `The Word`
-(do not mock data models).
-
-## Risks
-
-1. **Empty compliant pool.** Removing the `>=3` fallback may cause meal-plan
-   generation to fail for personas with very strict dietary needs if the recipe
-   corpus is too sparse. Mitigation: error path returns a structured message
-   the simulation/app can surface; the right fix is broader (more compliant
-   recipes), not silently serving non-compliant food.
-2. **Ranker assumes a populated input.** If the filter shrinks the pool below
-   `weeklyMealPrepCount`, the existing top-N selector at
-   `MealPlanAction.ts:157–161` should already handle that gracefully — verify
-   during implementation.
-3. **Duplication consolidation.** Centralizing `DIETARY_TAG_MAP` could break
-   `DietaryInvariant.ts` if its `label` field is used elsewhere. Adapter or
-   parallel structure keeps the validator working.
+No mocking of Firestore data models. Real arrays of strings as test inputs.
 
 ## Implementation Order
 
-1. Create `src/utils/dietaryFilter.ts` with the consolidated helpers.
-2. Update `MealPlanAction.ts`: filter before rank, remove fallback, import shared helpers.
-3. Update `DietaryInvariant.ts`: import shared map (keep label adapter).
-4. Add unit tests.
-5. Run simulation harness; confirm dietary violations drop to ~0 from 610.
-6. Run typecheck/lint/tests; commit; PR.
+1. Create `tagSanitizer.ts` with vocab tables, `isLikelyIngredientPhrase`, `cleanTags`.
+2. Write `tagSanitizer.test.ts`. Iterate rules until the canonical example and ~20 hand-picked corpus pollutants drop while known-good tags survive.
+3. Wire `dietaryFilter.ts` to use the sanitizer (delete or shrink `normalizeTags`).
+4. Wire `simulation/seed-data/import-recipes.ts` and `scripts/tasty-scraper/firestore-uploader.js`.
+5. Write `scripts/clean-corpus-tags.ts`. Run dry-run, eyeball the dropped-tag report.
+6. Commit cleaned JSON (or document the regeneration step in the PR — see QUESTIONS).
+7. Run `npm test` (jest) and the simulation; capture deltas.
+
+## Risks
+
+- **Over-aggressive heuristics drop legitimate tags.** Mitigation: dry-run report lists every dropped tag with frequencies before the user opts in to the Firestore write.
+- **Recipes with all-polluted tags end up empty.** Mitigation: report flags recipes whose tag count drops below 2 for manual inspection. Out-of-scope to backfill them; flag for follow-up.
+- **JS/TS interop in scrapers.** The Tasty scraper is plain JS. Worst case we duplicate the small denylist constants there; better case we run via `ts-node`. See QUESTIONS.
+- **Cleaned JSON in git.** `allrecipes_firestore.cleaned.json` is large. Consider gitignoring it and making the cleanup script reproducible from the original. See QUESTIONS.

--- a/KitchenSinkNew/package.json
+++ b/KitchenSinkNew/package.json
@@ -34,6 +34,7 @@
     "setup": "npm install && cd ios && pod install",
     "reset": "npm run clean && npm run setup",
     "debug:build": "node scripts/debug-build.js",
+    "clean:tags": "tsx scripts/clean-corpus-tags.ts",
     "demo:mealplan": "node scripts/simpleMealPlanDemo.js",
     "test:algorithm": "node scripts/testAlgorithmSimple.js",
     "simulate": "cd simulation && npx tsx index.ts",
@@ -102,6 +103,7 @@
     "playwright": "^1.41.2",
     "slugify": "^1.6.6",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.2",
     "typescript": "^4.9.4"
   },
   "private": true

--- a/KitchenSinkNew/scripts/clean-corpus-tags.ts
+++ b/KitchenSinkNew/scripts/clean-corpus-tags.ts
@@ -1,0 +1,261 @@
+import * as admin from 'firebase-admin';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cleanTags } from '../src/utils/tagSanitizer';
+
+type Recipe = Record<string, any>;
+
+type CorpusShape = 'array' | 'wrapped' | 'keyed';
+
+interface LoadedCorpus {
+  shape: CorpusShape;
+  recipes: Recipe[];
+  keys: string[];
+  raw: any;
+}
+
+interface CleanReport {
+  totalRecipes: number;
+  totalTagsBefore: number;
+  totalTagsAfter: number;
+  droppedFrequency: Map<string, number>;
+  underTwoTags: Array<{ id: string; name?: string; cleanedCount: number }>;
+}
+
+interface CliArgs {
+  input: string;
+  output: string;
+  limit: number | null;
+  applyFirestore: boolean;
+}
+
+const DEFAULT_INPUT = path.resolve(__dirname, '../allrecipes_firestore.json');
+const DEFAULT_OUTPUT = path.resolve(__dirname, '../allrecipes_firestore.cleaned.json');
+const FIRESTORE_BATCH_SIZE = 400;
+const TOP_DROPPED_LIMIT = 100;
+const UNDER_TWO_SAMPLE_SIZE = 20;
+const KNOWN_FLAGS = new Set(['--input', '--output', '--limit', '--apply-firestore']);
+
+function usage(): string {
+  return 'Usage: tsx scripts/clean-corpus-tags.ts [--input <path>] [--output <path>] [--limit <N>] [--apply-firestore]';
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    input: DEFAULT_INPUT,
+    output: DEFAULT_OUTPUT,
+    limit: null,
+    applyFirestore: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (!flag.startsWith('--')) {
+      throw new Error(`Unexpected positional argument: ${flag}\n${usage()}`);
+    }
+    if (!KNOWN_FLAGS.has(flag)) {
+      throw new Error(`Unknown flag: ${flag}\n${usage()}`);
+    }
+    if (flag === '--apply-firestore') {
+      args.applyFirestore = true;
+      continue;
+    }
+    const value = argv[++i];
+    if (value === undefined) {
+      throw new Error(`Flag ${flag} requires a value\n${usage()}`);
+    }
+    if (flag === '--input') args.input = path.resolve(value);
+    else if (flag === '--output') args.output = path.resolve(value);
+    else if (flag === '--limit') {
+      const n = Number(value);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`--limit must be a positive integer, got ${value}`);
+      }
+      args.limit = n;
+    }
+  }
+
+  return args;
+}
+
+function loadCorpus(filePath: string): LoadedCorpus {
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+  if (Array.isArray(raw)) {
+    return { shape: 'array', recipes: raw, keys: [], raw };
+  }
+  if (Array.isArray(raw.recipes)) {
+    return { shape: 'wrapped', recipes: raw.recipes, keys: [], raw };
+  }
+  const keys = Object.keys(raw);
+  return { shape: 'keyed', recipes: keys.map((k) => raw[k]), keys, raw };
+}
+
+function recipeId(recipe: Recipe, fallbackIndex: number): string {
+  return String(recipe.id ?? `recipe-${fallbackIndex}`);
+}
+
+function cleanCorpus(recipes: Recipe[], limit: number | null): {
+  cleanedRecipes: Recipe[];
+  report: CleanReport;
+} {
+  const slice = limit ? recipes.slice(0, limit) : recipes;
+  const droppedFrequency = new Map<string, number>();
+  const underTwoTags: CleanReport['underTwoTags'] = [];
+  let totalTagsBefore = 0;
+  let totalTagsAfter = 0;
+
+  const cleanedRecipes = slice.map((recipe, idx) => {
+    const before: string[] = Array.isArray(recipe.tags) ? recipe.tags : [];
+    const after = cleanTags(before);
+
+    totalTagsBefore += before.length;
+    totalTagsAfter += after.length;
+
+    const afterSet = new Set(after);
+    for (const tag of before) {
+      if (typeof tag !== 'string') continue;
+      const norm = tag.trim().toLowerCase();
+      if (!norm || afterSet.has(norm)) continue;
+      droppedFrequency.set(norm, (droppedFrequency.get(norm) ?? 0) + 1);
+    }
+
+    if (after.length < 2) {
+      underTwoTags.push({
+        id: recipeId(recipe, idx),
+        name: recipe.name ?? recipe.title,
+        cleanedCount: after.length,
+      });
+    }
+
+    return { ...recipe, tags: after };
+  });
+
+  return {
+    cleanedRecipes,
+    report: {
+      totalRecipes: cleanedRecipes.length,
+      totalTagsBefore,
+      totalTagsAfter,
+      droppedFrequency,
+      underTwoTags,
+    },
+  };
+}
+
+function rebuildCorpus(loaded: LoadedCorpus, cleanedRecipes: Recipe[]): unknown {
+  if (loaded.shape === 'array') return cleanedRecipes;
+  if (loaded.shape === 'wrapped') return { ...loaded.raw, recipes: cleanedRecipes };
+  const out: Record<string, Recipe> = {};
+  cleanedRecipes.forEach((recipe, idx) => {
+    out[loaded.keys[idx]] = recipe;
+  });
+  return out;
+}
+
+function writeCorpus(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+}
+
+function topDropped(frequency: Map<string, number>, n: number): Array<[string, number]> {
+  return Array.from(frequency.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, n);
+}
+
+function printReport(report: CleanReport, outputPath: string): void {
+  console.log('=== Tag Cleaning Report ===');
+  console.log(`Total recipes processed: ${report.totalRecipes}`);
+  console.log(`Total tags before:       ${report.totalTagsBefore}`);
+  console.log(`Total tags after:        ${report.totalTagsAfter}`);
+  console.log(`Tags dropped:            ${report.totalTagsBefore - report.totalTagsAfter}`);
+  console.log(`Unique dropped tags:     ${report.droppedFrequency.size}`);
+  console.log(`Output written to:       ${outputPath}`);
+
+  console.log(`\n--- Top ${TOP_DROPPED_LIMIT} dropped tags (count\\ttag) ---`);
+  for (const [tag, count] of topDropped(report.droppedFrequency, TOP_DROPPED_LIMIT)) {
+    console.log(`${count}\t${tag}`);
+  }
+
+  console.log(`\n--- Recipes with < 2 cleaned tags: ${report.underTwoTags.length} ---`);
+  const sample = report.underTwoTags.slice(0, UNDER_TWO_SAMPLE_SIZE);
+  for (const entry of sample) {
+    const name = entry.name ? ` — ${entry.name}` : '';
+    console.log(`  [${entry.cleanedCount}] ${entry.id}${name}`);
+  }
+  if (report.underTwoTags.length > sample.length) {
+    console.log(`  ... and ${report.underTwoTags.length - sample.length} more`);
+  }
+}
+
+function initFirestore(): admin.firestore.Firestore {
+  const usingEmulator = !!process.env.FIRESTORE_EMULATOR_HOST;
+  if (usingEmulator) {
+    console.log(`Firestore mode: emulator (${process.env.FIRESTORE_EMULATOR_HOST})`);
+    const app = admin.initializeApp({ projectId: 'kitchensink-sim' });
+    return app.firestore();
+  }
+  console.log('Firestore mode: production (applicationDefault credentials)');
+  const app = admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  return app.firestore();
+}
+
+async function applyFirestoreUpdate(cleanedRecipes: Recipe[]): Promise<void> {
+  const db = initFirestore();
+  const collection = db.collection('recipes');
+  let batch = db.batch();
+  let inBatch = 0;
+  let written = 0;
+
+  for (let i = 0; i < cleanedRecipes.length; i++) {
+    const recipe = cleanedRecipes[i];
+    const id = recipeId(recipe, i);
+    batch.update(collection.doc(id), { tags: recipe.tags });
+    inBatch++;
+
+    if (inBatch === FIRESTORE_BATCH_SIZE) {
+      await batch.commit();
+      written += inBatch;
+      console.log(`  Updated ${written} recipes...`);
+      batch = db.batch();
+      inBatch = 0;
+    }
+  }
+
+  if (inBatch > 0) {
+    await batch.commit();
+    written += inBatch;
+  }
+
+  console.log(`Firestore: updated tags on ${written} recipe documents.`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`Reading corpus from ${args.input}`);
+  const loaded = loadCorpus(args.input);
+  console.log(`Loaded ${loaded.recipes.length} recipes (shape: ${loaded.shape})`);
+
+  const { cleanedRecipes, report } = cleanCorpus(loaded.recipes, args.limit);
+
+  const sliceForOutput =
+    args.limit && loaded.shape === 'keyed'
+      ? { ...loaded, keys: loaded.keys.slice(0, args.limit) }
+      : loaded;
+  const payload = rebuildCorpus(sliceForOutput, cleanedRecipes);
+  writeCorpus(args.output, payload);
+  printReport(report, args.output);
+
+  if (args.applyFirestore) {
+    console.log('\n--- Applying tag updates to Firestore ---');
+    await applyFirestoreUpdate(cleanedRecipes);
+  } else {
+    console.log('\n(Dry run: pass --apply-firestore to write tag updates to Firestore.)');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/KitchenSinkNew/scripts/tasty-scraper/firestore-uploader.js
+++ b/KitchenSinkNew/scripts/tasty-scraper/firestore-uploader.js
@@ -1,3 +1,5 @@
+require('ts-node/register/transpile-only');
+const { cleanTags } = require('../../src/utils/tagSanitizer');
 const admin = require('firebase-admin');
 
 // Initialize Firebase Admin SDK if not already initialized
@@ -19,7 +21,7 @@ function convertToAppRecipe(scrapedRecipe) {
   const recipeId = generateRecipeId(scrapedRecipe.sourceUrl);
   
   // Determine meal type tags based on title and ingredients
-  const tags = generateRecipeTags(scrapedRecipe);
+  const tags = cleanTags(generateRecipeTags(scrapedRecipe));
   
   // Estimate cost (simple heuristic based on ingredient count)
   const estimatedCost = estimateRecipeCost(scrapedRecipe.ingredients);

--- a/KitchenSinkNew/simulation/seed-data/import-recipes.ts
+++ b/KitchenSinkNew/simulation/seed-data/import-recipes.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import * as fs from 'fs';
 import * as path from 'path';
+import { cleanTags } from '../../src/utils/tagSanitizer';
 
 process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
 
@@ -32,7 +33,8 @@ async function importRecipes(): Promise<void> {
   for (const recipe of recipes) {
     const id = recipe.id || `recipe-${count}`;
     const ref = db.collection('recipes').doc(String(id));
-    batch.set(ref, recipe);
+    const cleaned = { ...recipe, tags: cleanTags(recipe.tags) };
+    batch.set(ref, cleaned);
     count++;
     batchCount++;
 

--- a/KitchenSinkNew/src/utils/__tests__/tagSanitizer.test.ts
+++ b/KitchenSinkNew/src/utils/__tests__/tagSanitizer.test.ts
@@ -1,0 +1,199 @@
+import {
+  cleanTags,
+  isLikelyIngredientPhrase,
+} from '../tagSanitizer';
+
+describe('cleanTags - canonical Roasted Garlic Butter example', () => {
+  it('keeps allowlist tags and drops ingredient phrases', () => {
+    const raw = [
+      'american',
+      'bulb garlic',
+      'dinner',
+      'lightly salted whipped butter',
+      'olive oil to drizzle over garlic',
+      'vegetarian',
+    ];
+
+    const result = cleanTags(raw);
+
+    expect(result).toEqual(['american', 'dinner', 'vegetarian']);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 1: comma', () => {
+  it('drops tags containing a comma', () => {
+    const result = isLikelyIngredientPhrase('salt, pepper, garlic');
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 2: length', () => {
+  it('drops tags longer than 25 characters', () => {
+    const tag = 'abcdefghijklmnopqrstuvwxyzabcd';
+
+    const result = isLikelyIngredientPhrase(tag);
+
+    expect(tag.length).toBe(30);
+    expect(result).toBe(true);
+  });
+
+  it('keeps short single-word allowlist tags', () => {
+    const result = isLikelyIngredientPhrase('easy');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 3: word count', () => {
+  it('drops tags with four or more whitespace-separated words', () => {
+    const result = isLikelyIngredientPhrase('a b c d');
+
+    expect(result).toBe(true);
+  });
+
+  it('keeps single-word tags', () => {
+    const result = isLikelyIngredientPhrase('easy');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 4: prepositions', () => {
+  const cases = [
+    'onions for garnish',
+    'butter with herbs',
+    'salt to taste',
+    'cup of milk',
+    'oil over heat',
+    'recipe from grandma',
+    'ingredient in sauce',
+  ];
+
+  it.each(cases)('drops tag containing preposition phrase: %s', (tag) => {
+    const result = isLikelyIngredientPhrase(tag);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 5: measurement and prep tokens', () => {
+  const cases = [
+    '2 tablespoons sugar',
+    'chopped onions',
+    'room temperature butter',
+    'lightly salted',
+  ];
+
+  it.each(cases)('drops tag containing measurement or prep token: %s', (tag) => {
+    const result = isLikelyIngredientPhrase(tag);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('isLikelyIngredientPhrase - rule 6: ingredient noun without allowlist', () => {
+  it('drops a bare ingredient noun like "garlic"', () => {
+    const result = isLikelyIngredientPhrase('garlic');
+
+    expect(result).toBe(true);
+  });
+
+  it('drops "bulb garlic" because it has no allowlist token', () => {
+    const result = isLikelyIngredientPhrase('bulb garlic');
+
+    expect(result).toBe(true);
+  });
+
+  it('keeps a tag containing an ingredient noun if an allowlist token is present', () => {
+    const result = isLikelyIngredientPhrase('garlic shrimp american');
+
+    expect(result).toBe(false);
+  });
+
+  it('keeps a pure allowlist tag', () => {
+    const result = isLikelyIngredientPhrase('american');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('isLikelyIngredientPhrase - allowlist requires whole-word match', () => {
+  it('drops "snacky garlic" because "snack" is only a substring, not a whole word', () => {
+    const result = isLikelyIngredientPhrase('snacky garlic');
+
+    expect(result).toBe(true);
+  });
+
+  it('keeps "tex-mex" because the hyphenated vocab token matches with escaped regex', () => {
+    const result = isLikelyIngredientPhrase('tex-mex');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('isLikelyIngredientPhrase - multi-word allowlist tokens', () => {
+  it('keeps "best comfort food" because the multi-word vocab token matches', () => {
+    const result = isLikelyIngredientPhrase('best comfort food');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('cleanTags - hyphenated dietary tags', () => {
+  it('keeps gluten-free, low-carb, dairy-free, and nut-free', () => {
+    const result = cleanTags(['gluten-free', 'low-carb', 'dairy-free', 'nut-free']);
+
+    expect(result).toEqual(['gluten-free', 'low-carb', 'dairy-free', 'nut-free']);
+  });
+});
+
+describe('cleanTags - normalization and dedupe', () => {
+  it('trims, lowercases, and dedupes case-insensitively while preserving first-seen order', () => {
+    const raw = ['American', 'american', '  AMERICAN  ', 'Dinner'];
+
+    const result = cleanTags(raw);
+
+    expect(result).toEqual(['american', 'dinner']);
+  });
+});
+
+describe('cleanTags - empty inputs', () => {
+  it('returns an empty array for null', () => {
+    const result = cleanTags(null);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array for undefined', () => {
+    const result = cleanTags(undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array for an empty array', () => {
+    const result = cleanTags([]);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('cleanTags - non-string entries', () => {
+  it('ignores non-string entries without throwing', () => {
+    const raw = ['american', 42, null, undefined, 'dinner'] as unknown as string[];
+
+    const result = cleanTags(raw);
+
+    expect(result).toEqual(['american', 'dinner']);
+  });
+});
+
+describe('cleanTags - input order', () => {
+  it('preserves the original input order for surviving tags', () => {
+    const raw = ['vegetarian', 'american', 'dinner', 'easy'];
+
+    const result = cleanTags(raw);
+
+    expect(result).toEqual(['vegetarian', 'american', 'dinner', 'easy']);
+  });
+});

--- a/KitchenSinkNew/src/utils/dietaryFilter.ts
+++ b/KitchenSinkNew/src/utils/dietaryFilter.ts
@@ -1,4 +1,5 @@
 import { DietaryPreferences } from '../types/DietaryPreferences';
+import { cleanTags } from './tagSanitizer';
 
 /** A recipe shape sufficient for tag-based dietary filtering. */
 export interface RecipeWithTags {
@@ -50,11 +51,6 @@ export const DIETARY_TAG_MAP: Readonly<Record<string, ReadonlyArray<string>>> =
     ),
   );
 
-/** Lower-cases and trims a tag list once for matching. */
-function normalizeTags(tags: ReadonlyArray<string> | undefined): string[] {
-  return (tags ?? []).map(t => t.trim().toLowerCase());
-}
-
 /**
  * Return the requirements the recipe FAILS to satisfy given the user's
  * boolean dietary flags. Empty array means the recipe is compliant.
@@ -66,7 +62,7 @@ export function missingDietaryRequirements(
   recipe: RecipeWithTags,
   prefs: Partial<DietaryPreferences>,
 ): DietaryRequirement[] {
-  const tags = normalizeTags(recipe.tags);
+  const tags = cleanTags(recipe.tags);
   const missing: DietaryRequirement[] = [];
   for (const req of DIETARY_REQUIREMENTS) {
     const flag = prefs[req.key];

--- a/KitchenSinkNew/src/utils/tagSanitizer.ts
+++ b/KitchenSinkNew/src/utils/tagSanitizer.ts
@@ -1,0 +1,186 @@
+export const KNOWN_TAG_VOCABULARY: ReadonlySet<string> = new Set<string>([
+  'vegan',
+  'vegetarian',
+  'gluten-free',
+  'dairy-free',
+  'nut-free',
+  'low-carb',
+  'keto',
+  'paleo',
+  'pescatarian',
+  'kosher',
+  'halal',
+  'breakfast',
+  'lunch',
+  'dinner',
+  'snacks',
+  'snack',
+  'dessert',
+  'appetizer',
+  'side dish',
+  'main course',
+  'brunch',
+  'american',
+  'italian',
+  'mexican',
+  'asian',
+  'chinese',
+  'japanese',
+  'thai',
+  'indian',
+  'french',
+  'mediterranean',
+  'greek',
+  'middle eastern',
+  'southern',
+  'tex-mex',
+  'cajun',
+  'korean',
+  'vietnamese',
+  'spanish',
+  'german',
+  'british',
+  'baked',
+  'grilled',
+  'fried',
+  'roasted',
+  'slow cooker',
+  'instant pot',
+  'air fryer',
+  'one pot',
+  'no cook',
+  'make ahead',
+  'comfort food',
+  'healthy',
+  'quick',
+  'easy',
+  'kid friendly',
+  'holiday',
+  'summer',
+  'winter',
+  'spring',
+  'fall',
+]);
+
+export const INGREDIENT_NOUN_DENYLIST: ReadonlySet<string> = new Set<string>([
+  'garlic',
+  'butter',
+  'oil',
+  'sugar',
+  'flour',
+  'egg',
+  'milk',
+  'salt',
+  'pepper',
+  'onion',
+  'tomato',
+  'cheese',
+  'chicken',
+  'beef',
+  'pork',
+  'fish',
+  'shrimp',
+  'bread',
+  'rice',
+  'pasta',
+]);
+
+export const MEASUREMENT_TOKENS: ReadonlySet<string> = new Set<string>([
+  'teaspoon',
+  'tablespoon',
+  'tbsp',
+  'tsp',
+  'cup',
+  'ounce',
+  'oz',
+  'gram',
+  'lb',
+  'pound',
+  'drizzle',
+  'chopped',
+  'grated',
+  'sliced',
+  'diced',
+  'minced',
+  'peeled',
+  'melted',
+  'softened',
+  'whipped',
+  'room temperature',
+  'unsalted',
+  'lightly salted',
+]);
+
+const PREPOSITION_PHRASES: readonly string[] = [
+  ' to ',
+  ' for ',
+  ' with ',
+  ' of ',
+  ' over ',
+  ' from ',
+  ' in ',
+];
+
+const MAX_TAG_LENGTH = 25;
+const MAX_TAG_WORDS = 3;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+function containsAllowlistToken(tag: string): boolean {
+  for (const vocab of KNOWN_TAG_VOCABULARY) {
+    const pattern = new RegExp(`\\b${escapeRegExp(vocab)}\\b`);
+    if (pattern.test(tag)) return true;
+  }
+  return false;
+}
+
+function containsMeasurementToken(tag: string): boolean {
+  for (const token of MEASUREMENT_TOKENS) {
+    if (tag.includes(token)) return true;
+  }
+  return false;
+}
+
+function containsIngredientNoun(tag: string): boolean {
+  for (const noun of INGREDIENT_NOUN_DENYLIST) {
+    const wordBoundary = new RegExp(`\\b${noun}\\b`);
+    if (wordBoundary.test(tag)) return true;
+  }
+  return false;
+}
+
+export function isLikelyIngredientPhrase(tag: string): boolean {
+  if (tag.includes(',')) return true;
+  if (tag.length > MAX_TAG_LENGTH) return true;
+
+  const words = tag.split(/\s+/).filter(Boolean);
+  if (words.length > MAX_TAG_WORDS) return true;
+
+  const padded = ` ${tag} `;
+  for (const phrase of PREPOSITION_PHRASES) {
+    if (padded.includes(phrase)) return true;
+  }
+
+  if (containsMeasurementToken(tag)) return true;
+
+  if (containsIngredientNoun(tag) && !containsAllowlistToken(tag)) return true;
+
+  return false;
+}
+
+export function cleanTags(raw: readonly string[] | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const t of raw) {
+    if (typeof t !== 'string') continue;
+    const norm = t.trim().toLowerCase();
+    if (!norm || seen.has(norm)) continue;
+    if (isLikelyIngredientPhrase(norm)) continue;
+    seen.add(norm);
+    result.push(norm);
+  }
+  return result;
+}

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,65 +1,41 @@
-# Fix Dietary Filter Veto
+# Plan: Clean Recipe Tags
 
-## Problem
+See `IMPLEMENTATION_SPEC.md` (canonical). This file mirrors it for PR visibility.
 
-The simulation harness emits 658 invariant violations; **610 (93%)** match the pattern
-`Recipe "X" lacks required Y tag for Y preference`. The planner serves vegan-explorer
-non-vegan recipes (e.g. "Roasted Garlic Butter", "Dina's Hot and Spicy Tuna"),
-serves dairy-free-beginner dairy-laden recipes ("Broccoli Rice and Cheese"), and
-serves allergy-aware-japanese (gluten-free + nut-free required) recipes carrying
-neither tag.
+## TL;DR
 
-## Root Cause
+The corpus has ingredient phrases polluting recipe tags (e.g. `'olive oil to drizzle over garlic'` next to `'american'`, `'dinner'`, `'vegetarian'`). Every tag-based filter (dietary veto, seasonal prior, cuisine lookup) is operating on a contaminated index.
 
-`KitchenSinkNew/simulation/actions/MealPlanAction.ts:148–155`:
+Fix:
+1. New `tagSanitizer.ts` — single shared `cleanTags()` using structural heuristics + an ingredient-noun denylist.
+2. Backfill script — produces `allrecipes_firestore.cleaned.json` and optionally updates Firestore.
+3. Wire the sanitizer into the dietary filter, the simulation importer, and the Tasty scraper so new pollution can't enter.
 
-```ts
-const filtered = scored.filter(s => passesDietaryFilter(s.recipe, dietary));
-const candidates = filtered.length >= 3 ? filtered : scored;
-```
+## Heuristic rules (drop a tag if any apply)
 
-When fewer than 3 ranked recipes pass the dietary filter, the filter is **silently
-discarded** and the unfiltered ranked list is used. This is the dominant source
-of the 93% violation rate.
-
-Two contributing structural problems:
-
-1. **Filter runs after the ranker.** The ranker scores generic appeal with no
-   dietary awareness, so non-compliant recipes dominate the top of the list and
-   the post-filter discards most of the candidate pool — triggering the fallback.
-2. **No hard veto.** Dietary preferences are treated as soft annotations rather
-   than mandatory constraints.
-
-The mapping logic itself and tag normalization are correct. The bug is the
-silent fallback plus pipeline ordering.
-
-## Approach
-
-1. **Filter before ranking.** Move the dietary filter upstream of `rankRecipes()`.
-2. **Remove the fallback.** No silent relaxation; surface a clear diagnostic if
-   the compliant pool is empty.
-3. **Promote the helpers** into `src/utils/dietaryFilter.ts` so the production app
-   and the invariant validator share one source of truth (DRY).
-4. **Tests** for veto, multi-constraint personas, and empty pools.
+1. Contains a comma.
+2. Length > 25 chars.
+3. ≥ 4 whitespace words.
+4. Contains preposition phrase (` to `, ` for `, ` with `, ` of `, ` over `, ` from `, ` in `).
+5. Contains a measurement / prep token (`teaspoon`, `cup`, `drizzle`, `chopped`, `whipped`, `room temperature`, `lightly salted`, …).
+6. Contains an ingredient-root noun (`garlic`, `butter`, `oil`, `sugar`, `flour`, `egg`, `milk`, `cheese`, `chicken`, `beef`, …) AND no allowlisted category word.
 
 ## Files
 
-| File | Change |
-|------|--------|
-| `KitchenSinkNew/src/utils/dietaryFilter.ts` | **NEW** — `DIETARY_TAG_MAP`, `passesDietaryFilter`, `filterByDiet` |
-| `KitchenSinkNew/simulation/actions/MealPlanAction.ts` | Filter before rank; remove fallback |
-| `KitchenSinkNew/simulation/invariants/DietaryInvariant.ts` | Consume shared map |
-| `KitchenSinkNew/src/utils/__tests__/dietaryFilter.test.ts` | **NEW** — unit tests |
+- New: `KitchenSinkNew/src/utils/tagSanitizer.ts`
+- New: `KitchenSinkNew/src/utils/__tests__/tagSanitizer.test.ts`
+- New: `KitchenSinkNew/scripts/clean-corpus-tags.ts`
+- Modify: `KitchenSinkNew/src/utils/dietaryFilter.ts`
+- Modify: `KitchenSinkNew/scripts/tasty-scraper/firestore-uploader.js`
+- Modify: `KitchenSinkNew/simulation/seed-data/import-recipes.ts`
 
-## Risks
+## Validation
 
-1. Empty compliant pool may cause persona meal-plan failure — surface as
-   structured error rather than silent fallback.
-2. Top-N selector at `MealPlanAction.ts:157` must handle pools smaller than
-   `weeklyMealPrepCount` (verify in implementation).
-3. `DietaryInvariant.ts` uses a `label` field; consolidation needs an adapter.
+- Unit tests in `tagSanitizer.test.ts` — 27 cases covering canonical example, all six rules, normalization, dedupe, null/undefined.
+- Existing `dietaryFilter.test.ts` still passes — `cleanTags` is a strict superset of the old `normalizeTags` for all dietary vocab tokens.
+- Re-run simulation harness; dietary invariant must remain at zero violations; seasonal signal distribution should sharpen.
+- Dry-run report before any Firestore write — top 100 dropped tags reviewed manually.
 
-## Verification
+## Implementation status
 
-Re-run simulation harness; dietary-tag violation count must drop to ~0 from 610
-for vegan-explorer, dairy-free-beginner, and allergy-aware-japanese personas.
+All six files done. Sanitizer + 27 unit tests pass. `dietaryFilter.ts` delegates to `cleanTags` (24 tests pass). Importer and Tasty scraper guard tags at write time. Backfill script smoke-tested on a 50-recipe slice — drops obvious pollution (`cream cheese`, `brown sugar`, `baking potatoes, baked`) while preserving real tags. JS↔TS interop in the scraper uses `ts-node/register/transpile-only`.

--- a/QUESTIONS.md
+++ b/QUESTIONS.md
@@ -1,69 +1,38 @@
-# Open Questions — Fix Dietary Filter Veto
+# Open Questions — Clean Recipe Tags
 
 Living doc. Questions flagged during planning; append as implementation sub-agents surface more.
 
 ## Planning-phase
 
-1. **Empty compliant pool — error vs. partial plan?** If a persona's dietary
-   constraints leave fewer than `weeklyMealPrepCount` compliant recipes, should
-   the planner (a) error out, (b) emit a partial plan with a warning, or (c)
-   try a fallback corpus? Current spec assumes error / structured diagnostic.
+1. **Should `allrecipes_firestore.cleaned.json` be checked into git?**
+   It's likely tens of MB. Options: (a) commit it as the new canonical corpus, (b) `.gitignore` it and document regeneration, (c) replace the original after review. Recommendation: (c) — replace the original in a follow-up commit once the dry-run report is reviewed.
+c.
 
-B.
+2. **JS ↔ TS in the Tasty scraper.**
+   `scripts/tasty-scraper/firestore-uploader.js` is plain JS. Three options for using `cleanTags`:
+   (a) run the scraper via `ts-node` against `tagSanitizer.ts`,
+   (b) ship a small JS port of the sanitizer (duplication risk),
+   (c) build TS → JS into a `dist/` and require it.
+   No precedent in this repo as of planning. Defer the decision to implementation; flag here.
 
-2. **Should the ranker score dietary fit as a soft signal too?** Filtering
-   upstream is sufficient for correctness, but a small bonus on positive tags
-   could improve diversity within the compliant pool. Out of scope for this PR
-   unless the simulation surfaces a related issue.
+3. **Cuisine vocabulary completeness.**
+   The `KNOWN_TAG_VOCABULARY` cuisines list is best-guess from the example plus common cuisines. We don't have a corpus-wide histogram of legitimate cuisine tags. Implementation step 5 (dry-run report) will surface any common cuisine that gets dropped — we extend the vocab if so.
 
-yes
+4. **Should rule 6 also accept `'garlic shrimp'`-style legitimate dish descriptors?**
+   The plan accepts dropping these — they aren't standardized tags and tag-based filters don't depend on them. If review feedback says otherwise, the fix is to add a small dish-descriptor allowlist.
+that works
 
-3. **`DietaryInvariant.ts` `label` field** — is the human-readable label used
-   anywhere besides the violation message? If so, the shared map needs to
-   carry it; if not, we can keep it local to the validator with a thin
-   adapter.
+5. **Tasty corpus pollution audit.**
+   `generateRecipeTags()` in the Tasty pipeline was not opened during reconnaissance. Implementation should glance at it to confirm it doesn't ingest free-text fields. If it does, rule 6 there too.
 
-not sure
-
-4. **Production app pipeline** — the `MealPlanAction` we are fixing lives
-   under `simulation/actions/`. Does the actual production app
-   (`src/services/...` or similar) have its own meal-plan generator that
-   shares this bug? Worth a quick check during implementation; if so, the
-   shared utility benefits both.
-
-i think so
-
-5. **Allergies & restrictions** — out of scope here, but the
-   `DietaryPreferences.allergies` and `restrictions` arrays are currently
-   ignored by the filter. Worth a follow-up if allergy violations show up in
-   the simulation report.
+   _Resolved during implementation:_ `generateRecipeTags` infers tags from `recipe.title` and `recipe.ingredients` substrings (e.g. `'chicken'`, `'curry'`). Raw ingredient text can flow through. The new `cleanTags` wrapper at the upload site catches any pollution defensively.
 
 ## Implementation-phase
 
-6. **Lost spaced-variant tag aliases.** The previous local `DIETARY_TAG_REQUIREMENTS`
-   in `DietaryInvariant.ts` accepted both hyphenated (`'gluten-free'`) and
-   spaced (`'gluten free'`) forms, plus `'keto'` as a low-carb alias. The
-   shared module accepts only hyphenated. Per planning assumption #4, the
-   ingest-time normalization in `recipeMappers.ts` makes the spaced forms
-   unreachable in practice. **Open follow-up:** if any legacy
-   recipe data bypasses the mapper, those tags will now produce false-positive
-   violations.
+6. **Should `--apply-firestore` skip recipes whose cleaned tag count drops below a threshold?**
+   Current behavior writes whatever `cleanTags` returns, including `[]`. Risk: a heavily polluted recipe could end up with zero tags in production, becoming invisible to tag-driven rankers. The dry-run report already lists these recipes for manual review. Recommendation: review the report on the full corpus before running `--apply-firestore`; if the count is non-trivial, add a `--min-tags <N>` skip filter in a follow-up.
 
-7. **Q2 (ranker dietary bonus) deferred.** Filtering upstream gives the ranker
-   a fully-compliant pool, so a "dietary fit" feature would be a constant 1.0.
-   No-op for ranking. Re-open only if a future change reintroduces non-veto
-   dietary handling.
+7. **Should `cleanTags` accept a small "dish descriptor" allowlist for phrases like `'garlic shrimp'`?**
+   Carried over from planning question 4. The user annotated "that works" — so dropping these is intentional. Keep as-is.
 
-8. **Production `essentialDietaryFilter` promoted from 2-flag to 6-flag gate.**
-   The original code only hard-rejected vegan/vegetarian violations and
-   relegated `glutenFree`/`dairyFree`/`nutFree`/`lowCarb` to soft scoring
-   penalties. This was the precise pattern that let nut-free and low-carb
-   violations through. The promotion may shrink eligible-recipe pools more
-   aggressively for users with strict combos — the relaxation-level fallback
-   in `mealPlanSelector` should still produce a partial plan rather than
-   panic, but this is worth watching in production.
-
-9. **`mealPlanSelector` test failures pre-existing.** `src/tests/mealPlanSelector.test.ts`
-   has unrelated typecheck errors (`cuisines` missing from `Recipe`,
-   `FoodPreferences` shape drift). Not introduced by this PR; not fixed by this PR.
-
+8. **JS↔TS interop choice for the Tasty scraper resolved to option (a):** `ts-node/register/transpile-only`. `ts-node` is in devDependencies. Smoke test confirms the require chain loads cleanly.


### PR DESCRIPTION
# Plan: Clean Recipe Tags

See `IMPLEMENTATION_SPEC.md` (canonical). This file mirrors it for PR visibility.

## TL;DR

The corpus has ingredient phrases polluting recipe tags (e.g. `'olive oil to drizzle over garlic'` next to `'american'`, `'dinner'`, `'vegetarian'`). Every tag-based filter (dietary veto, seasonal prior, cuisine lookup) is operating on a contaminated index.

Fix:
1. New `tagSanitizer.ts` — single shared `cleanTags()` using structural heuristics + an ingredient-noun denylist.
2. Backfill script — produces `allrecipes_firestore.cleaned.json` and optionally updates Firestore.
3. Wire the sanitizer into the dietary filter, the simulation importer, and the Tasty scraper so new pollution can't enter.

## Heuristic rules (drop a tag if any apply)

1. Contains a comma.
2. Length > 25 chars.
3. ≥ 4 whitespace words.
4. Contains preposition phrase (` to `, ` for `, ` with `, ` of `, ` over `, ` from `, ` in `).
5. Contains a measurement / prep token (`teaspoon`, `cup`, `drizzle`, `chopped`, `whipped`, `room temperature`, `lightly salted`, …).
6. Contains an ingredient-root noun (`garlic`, `butter`, `oil`, `sugar`, `flour`, `egg`, `milk`, `cheese`, `chicken`, `beef`, …) AND no allowlisted category word.

## Files

- New: `KitchenSinkNew/src/utils/tagSanitizer.ts`
- New: `KitchenSinkNew/src/utils/__tests__/tagSanitizer.test.ts`
- New: `KitchenSinkNew/scripts/clean-corpus-tags.ts`
- Modify: `KitchenSinkNew/src/utils/dietaryFilter.ts`
- Modify: `KitchenSinkNew/scripts/tasty-scraper/firestore-uploader.js`
- Modify: `KitchenSinkNew/simulation/seed-data/import-recipes.ts`

## Validation

- Unit tests in `tagSanitizer.test.ts` — 27 cases covering canonical example, all six rules, normalization, dedupe, null/undefined.
- Existing `dietaryFilter.test.ts` still passes — `cleanTags` is a strict superset of the old `normalizeTags` for all dietary vocab tokens.
- Re-run simulation harness; dietary invariant must remain at zero violations; seasonal signal distribution should sharpen.
- Dry-run report before any Firestore write — top 100 dropped tags reviewed manually.

## Implementation status

All six files done. Sanitizer + 27 unit tests pass. `dietaryFilter.ts` delegates to `cleanTags` (24 tests pass). Importer and Tasty scraper guard tags at write time. Backfill script smoke-tested on a 50-recipe slice — drops obvious pollution (`cream cheese`, `brown sugar`, `baking potatoes, baked`) while preserving real tags. JS↔TS interop in the scraper uses `ts-node/register/transpile-only`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe tags are now automatically sanitized to remove ingredient phrases and contamination, improving recipe search and dietary filtering accuracy.
  * Added backfill capability to clean existing recipe tags and optionally sync updates to the backend.

* **Tests**
  * Added comprehensive test suite for tag sanitization with 27+ test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->